### PR TITLE
Move to `zeroize` for sensitive data

### DIFF
--- a/bulletproofs/Cargo.toml
+++ b/bulletproofs/Cargo.toml
@@ -19,13 +19,13 @@ rand = { version = "0.8", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
 thiserror = { version = "1", optional = true }
 merlin = { version = "2", default-features = false }
-clear_on_drop = { version = "0.2", default-features = false }
 ark-ec = { version = "0.4.0"}
 ark-ff = { version = "0.4.0"}
 ark-serialize = { version = "0.4.0" } 
 ark-std = { version = "0.4.0" } 
 rust-crypto = "^0.2"
 rayon = {version = "1.5.3", optional = true}
+zeroize = { version = "1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -38,7 +38,6 @@ default = ["std", "parallel", "asm"]
 std = ["rand", "rand/std", "thiserror"]
 asm = ["ark-ff/asm"]
 parallel = ["ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel", "rayon"]
-nightly = ["clear_on_drop/nightly"]
 
 [[test]]
 name = "r1cs"


### PR DESCRIPTION
This PR moves the handling of sensitive data from [`clear_on_drop`](https://crates.io/crates/clear_on_drop/) to the more modern and standard [`zeroize`](https://crates.io/crates/zeroize). Its `ZeroizeOnDrop` derived trait allows for a cleaner approach to zeroizing that doesn't require manually implementing `Drop`, and the use of its `Zeroizing` wrapper ensures that data is zeroized even in the case of an unexpected early return.

The repository [documentation](https://github.com/simonkamp/curve-trees#readme) does note that it is not intended for production use, but it already takes a proactive approach to handling sensitive data that seems like a great idea.